### PR TITLE
Fixes for body text not appearing in 3.3

### DIFF
--- a/JatsTemplatePlugin.inc.php
+++ b/JatsTemplatePlugin.inc.php
@@ -245,7 +245,7 @@ class JatsTemplatePlugin extends GenericPlugin {
 					$purifier = new HTMLPurifier($config);
 				}
 				// Remove non-paragraph content
-				$text = $purifier->purify(file_get_contents($filepath));
+				$text = $purifier->purify(file_get_contents(Config::getVar('files', 'files_dir') . '/' . $filepath));
 				// Remove empty paragraphs
 				$text = preg_replace('/<p>[\W]*<\/p>/', '', $text);
 			} else {
@@ -255,7 +255,7 @@ class JatsTemplatePlugin extends GenericPlugin {
 					$parser->close();
 				}
 
-				$text = '<p>' . htmlspecialchars($text) . '</p>';
+				$text = '<p>' . htmlspecialchars($text, ENT_IGNORE) . '</p>';
 			}
 			// Use the first parseable galley.
 			if (!empty($text)) break;


### PR DESCRIPTION
Since upgrading some of our instances to 3.3.0.6 the full body text stopped appearing. These changes appear to fix the issue. The HTML galley file path was missing file directory path and the indexed PDF body text was breaking the htmlspecialchars function because of special character issues. Adding the ignore flag fixes the issue, but I'm not sure what's changed between 3.1.2 and 3.3.x to have caused this problem.

