### PR TITLE
Remove deprecated AppLocale-related code

### DIFF
--- a/JatsTemplatePlugin.inc.php
+++ b/JatsTemplatePlugin.inc.php
@@ -190,7 +190,6 @@ class JatsTemplatePlugin extends GenericPlugin {
 			$pageCount = $matchedPageTo - $matchedPageFrom + 1;
 		}
 
-		AppLocale::requireComponents(LOCALE_COMPONENT_PKP_SUBMISSION);
 		$copyrightYear = $article->getCopyrightYear();
 		$copyrightHolder = $article->getLocalizedCopyrightHolder();
 		$licenseUrl = $article->getLicenseURL();


### PR DESCRIPTION
This removes a deprecated call to `AppLocale::requireComponents` that was causing a fatal error in OJS 3.4 (`main` branch) using PHP 8.0.