### PR TITLE
pkp/pkp-lib#10786 fix page regex and cleanup formatting

### DIFF
--- a/JatsTemplateDownloadHandler.php
+++ b/JatsTemplateDownloadHandler.php
@@ -13,85 +13,98 @@
 
 namespace APP\plugins\generic\jatsTemplate;
 
+use PKP\core\PKPRequest;
+use PKP\security\Role;
+use PKP\security\RoleDAO;
 use PKP\submissionFile\SubmissionFile;
 use PKP\db\DAORegistry;
 use PKP\config\Config;
 use APP\facades\Repo;
 use APP\handler\Handler;
 use Firebase\JWT\JWT;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class JatsTemplateDownloadHandler extends Handler {
-	/** @var JatsTemplatePlugin The JATS Template plugin */
-	var $plugin;
+class JatsTemplateDownloadHandler extends Handler
+{
+    /** @var JatsTemplatePlugin The JATS Template plugin */
+    public JatsTemplatePlugin $plugin;
 
-	/**
-	 * Constructor
-	 */
-	function __construct(JatsTemplatePlugin $plugin) {
-		$this->plugin = $plugin;
-	}
+    /**
+     * Constructor
+     */
+    public function __construct(JatsTemplatePlugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
 
-	/**
-	 * @copydoc PKPHandler::authorize()
-	 */
-	function authorize($request, &$args, $roleAssignments) {
-		// Permit the use of the Authorization header and an API key for access to unpublished/subscription content
-		if ($header = array_search('Authorization', array_flip(getallheaders()))) {
-			list($bearer, $jwt) = explode(' ', $header);
-			if (strcasecmp($bearer, 'Bearer') == 0) {
-				$apiToken = JWT::decode($jwt, Config::getVar('security', 'api_key_secret', ''), array('HS256'));
-				$this->setApiToken($apiToken);
-			}
-		}
+    /**
+     * @copydoc PKPHandler::authorize()
+     */
+    public function authorize($request, &$args, $roleAssignments)
+    {
+        // Permit the use of the Authorization header and an API key for access to unpublished/subscription content
+        if ($header = array_search('Authorization', array_flip(getallheaders()))) {
+            list($bearer, $jwt) = explode(' ', $header);
+            if (strcasecmp($bearer, 'Bearer') == 0) {
+                $apiToken = JWT::decode($jwt, Config::getVar('security', 'api_key_secret', ''), array('HS256'));
+                $this->setApiToken($apiToken);
+            }
+        }
 
-		$this->addPolicy(new \PKP\security\authorization\ContextRequiredPolicy($request));
-		$this->addPolicy(new \APP\security\authorization\OjsJournalMustPublishPolicy($request));
+        $this->addPolicy(new \PKP\security\authorization\ContextRequiredPolicy($request));
+        $this->addPolicy(new \APP\security\authorization\OjsJournalMustPublishPolicy($request));
 
-		return parent::authorize($request, $args, $roleAssignments);
-	}
+        return parent::authorize($request, $args, $roleAssignments);
+    }
 
-	protected function _isUserAllowedAccess($request) {
-		$user = $request->getUser();
-		$context = $request->getContext();
-		if (!$user || !$context) return false;
-		$roleDao = DAORegistry::getDAO('RoleDAO'); /** @var $roleDao RoleDAO */
-		$roles = $roleDao->getByUserId($user->getId(), $context->getId());
-		$allowedAccess = false;
-		foreach ($roles as $role) {
-			if (in_array($role->getRoleId(), [ROLE_ID_MANAGER, ROLE_ID_SUBSCRIPTION_MANAGER])) return true;
-		}
-		return false;
-	}
+    protected function _isUserAllowedAccess($request)
+    {
+        $user = $request->getUser();
+        $context = $request->getContext();
+        if (!$user || !$context) {
+            return false;
+        }
+        $roleDao = DAORegistry::getDAO('RoleDAO'); /** @var $roleDao RoleDAO */
+        $roles = $roleDao->getByUserId($user->getId(), $context->getId());
+        foreach ($roles as $role) {
+            if (in_array($role->getRoleId(), [Role::ROLE_ID_MANAGER, Role::ROLE_ID_SUBSCRIPTION_MANAGER])) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	/**
-	 * Handle a download request
-	 * @param $args array Arguments array.
-	 * @param $request PKPRequest Request object.
-	 */
-	function download($args, $request) {
-		if (!$this->_isUserAllowedAccess($request)) {
-			throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException();
-		}
+    /**
+     * Handle a download request
+     * @param $args array Arguments array.
+     * @param $request PKPRequest Request object.
+     */
+    public function download($args, $request)
+    {
+        if (!$this->_isUserAllowedAccess($request)) {
+            throw new NotFoundHttpException();
+        }
 
-		// Check the stage (this is only for consistency with other download URLs in the system
-		// in case the built-in download handler can be used in place of this in the future)
-		if ($request->getUserVar('stageId') != WORKFLOW_STAGE_ID_PRODUCTION) {
-			throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException();
-		}
+        // Check the stage (this is only for consistency with other download URLs in the system
+        // in case the built-in download handler can be used in place of this in the future)
+        if ($request->getUserVar('stageId') != WORKFLOW_STAGE_ID_PRODUCTION) {
+            throw new NotFoundHttpException();
+        }
 
-		$submissionId = $request->getUserVar('submissionId');
-		$layoutFiles = Repo::submissionFile()->getCollector()
-			->filterBySubmissionIds([$submissionId])
-			->filterByFileStages([SubmissionFile::SUBMISSION_FILE_PRODUCTION_READY])
-			->getMany();
-		foreach ($layoutFiles as $layoutFile) {
-			if ($layoutFile->getId() != $request->getUserVar('submissionFileId') || $layoutFile->getData('fileId') != $request->getUserVar('fileId')) continue;
+        $submissionId = $request->getUserVar('submissionId');
+        $layoutFiles = Repo::submissionFile()->getCollector()
+            ->filterBySubmissionIds([$submissionId])
+            ->filterByFileStages([SubmissionFile::SUBMISSION_FILE_PRODUCTION_READY])
+            ->getMany();
+        foreach ($layoutFiles as $layoutFile) {
+            if ($layoutFile->getId() != $request->getUserVar('submissionFileId') || $layoutFile->getData('fileId') != $request->getUserVar('fileId')) {
+                continue;
+            }
 
-			$filename = app()->get('file')->formatFilename($layoutFile->getData('path'), $layoutFile->getLocalizedData('name'));
-			app()->get('file')->download($layoutFile->getData('fileId'), $filename);
-			return;
-		}
-		throw new \Symfony\Component\HttpKernel\Exception\NotFoundHttpException();
-	}
+            $filename = app()->get('file')->formatFilename($layoutFile->getData('path'), $layoutFile->getLocalizedData('name'));
+            app()->get('file')->download($layoutFile->getData('fileId'), $filename);
+            return;
+        }
+        throw new NotFoundHttpException();
+    }
 }
-

--- a/classes/Article.php
+++ b/classes/Article.php
@@ -10,7 +10,6 @@
  * @brief JATS xml article
  */
 
-
 namespace APP\plugins\generic\jatsTemplate\classes;
 
 use APP\core\Application;
@@ -24,7 +23,7 @@ use PKP\oai\OAIRecord;
 
 class Article extends \DOMDocument
 {
-    function __construct()
+    public function __construct()
     {
         parent::__construct('1.0', 'UTF-8');
     }
@@ -49,10 +48,10 @@ class Article extends \DOMDocument
     public function convertSubmission(Submission $submission, Context $context, Section $section, ?Issue $issue = null, ?Publication $publication = null, PKPRequest $request = null): void
     {
         $articleElement = $this->appendChild($this->createElement('article'))
-            ->setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink')->parentNode
+            ->setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink')->parentNode
             ->setAttribute('xml:lang', str_replace(['_', '@'], '-', $submission->getData('locale')))->parentNode
-            ->setAttribute('xmlns:mml','http://www.w3.org/1998/Math/MathML')->parentNode
-            ->setAttribute('xmlns:xsi','http://www.w3.org/2001/XMLSchema-instance')->parentNode;
+            ->setAttribute('xmlns:mml', 'http://www.w3.org/1998/Math/MathML')->parentNode
+            ->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')->parentNode;
 
         $articleFront = new ArticleFront();
         $articleElement->appendChild($this->importNode($articleFront->create($context, $submission, $section, $issue, $request, $this, $publication), true));
@@ -74,15 +73,14 @@ class Article extends \DOMDocument
     public function mapHtmlTagsForTitle(string $htmlTitle): string
     {
         $mappings = [
-            '<b>' 	=> '<bold>',
-            '</b>' 	=> '</bold>',
-            '<i>' 	=> '<italic>',
-            '</i>' 	=> '</italic>',
-            '<u>' 	=> '<underline>',
-            '</u>' 	=> '</underline>',
+            '<b>'   => '<bold>',
+            '</b>'  => '</bold>',
+            '<i>'   => '<italic>',
+            '</i>'  => '</italic>',
+            '<u>'   => '<underline>',
+            '</u>'  => '</underline>',
         ];
 
         return str_replace(array_keys($mappings), array_values($mappings), $htmlTitle);
     }
-
 }

--- a/classes/ArticleBack.php
+++ b/classes/ArticleBack.php
@@ -21,7 +21,7 @@ class ArticleBack extends \DOMDocument
      * @param $publication
      * @return \DOMNode
      */
-    public function create($publication):\DOMNode
+    public function create($publication): \DOMNode
     {
         // create element back
         $backElement = $this->appendChild($this->createElement('back'));
@@ -31,12 +31,12 @@ class ArticleBack extends \DOMDocument
         if (count($citations)) {
             // create element ref-list
             $refListElement = $backElement->appendChild($this->createElement('ref-list'));
-            $i=1;
+            $i = 1;
             foreach ($citations as $citation) {
                 // create element ref
                 $refListElement
                     ->appendChild($this->createElement('ref'))
-                    ->setAttribute('id','R'.$i)
+                    ->setAttribute('id', 'R' . $i)
                     ->parentNode
                     ->appendChild($this->createElement('mixed-citation', htmlspecialchars($citation->getRawCitation())));
                 $i++;

--- a/classes/ArticleBody.php
+++ b/classes/ArticleBody.php
@@ -15,7 +15,6 @@ namespace APP\plugins\generic\jatsTemplate\classes;
 use APP\facades\Repo;
 use APP\submission\Submission;
 use PKP\config\Config;
-use PKP\core\PKPString;
 use PKP\galley\Galley;
 use PKP\search\SearchFileParser;
 
@@ -26,16 +25,16 @@ class ArticleBody extends \DOMDocument
      * @param Submission $submission
      * @return \DOMNode
      */
-    public function create(Submission $submission):\DOMNode
+    public function create(Submission $submission): \DOMNode
     {
         // create element body
         $bodyElement = $this->appendChild($this->createElement('body'));
         $text = '';
-        $galleys = $submission->getCurrentPublication()->getData('galleys');
+        $galleys = $submission->getCurrentPublication()->getData('galleys')->toArray();
 
         // Get HTML galleys for top of list, as they're quickest to parse
         // PDFs have second-highest priority over other file types
-        $items = array_reduce($galleys, function(array $carry, Galley $galley) {
+        $items = array_reduce($galleys, function (array $carry, Galley $galley) {
             $fileType = $galley->getFileType();
 
             switch ($fileType) {
@@ -56,7 +55,9 @@ class ArticleBody extends \DOMDocument
         $fileService = app()->get('file');
         foreach ($galleys as $galley) {
             $galleyFile = Repo::submissionFile()->get((int) $galley->getData('submissionFileId'));
-            if (!$galleyFile) continue;
+            if (!$galleyFile) {
+                continue;
+            }
 
             $filepath = $fileService->get($galleyFile->getData('fileId'))->path;
             $mimeType = $fileService->fs->mimeType($filepath);
@@ -75,7 +76,9 @@ class ArticleBody extends \DOMDocument
             } else {
                 $parser = SearchFileParser::fromFile($galleyFile);
                 if ($parser && $parser->open()) {
-                    while(($s = $parser->read()) !== false) $text .= $s;
+                    while (($s = $parser->read()) !== false) {
+                        $text .= $s;
+                    }
                     $parser->close();
                 }
                 if (!empty($text)) {
@@ -87,7 +90,9 @@ class ArticleBody extends \DOMDocument
                 }
             }
             // Use the first parseable galley.
-            if (!empty($text)) break;
+            if (!empty($text)) {
+                break;
+            }
         }
 
         return $bodyElement;

--- a/classes/ArticleFront.php
+++ b/classes/ArticleFront.php
@@ -3,8 +3,8 @@
 /**
  * @file ArticleFront.php
  *
- * Copyright (c) 2003-2022 Simon Fraser University
- * Copyright (c) 2003-2022 John Willinsky
+ * Copyright (c) 2003-2025 Simon Fraser University
+ * Copyright (c) 2003-2025 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
  *
  * @brief JATS xml article front element
@@ -53,16 +53,14 @@ class ArticleFront extends \DOMDocument
 
         $journalMetaElement->appendChild($this->createJournalMetaJournalTitleGroup($journal));
 
-        $publisherCountry = $journal->getSetting('country');
-        $publisherUrl = $journal->getSetting('publisherUrl');
         $publisherElement = $journalMetaElement->appendChild($this->createElement('publisher'));
         $publisherElement->appendChild($this->createElement('publisher-name'))
-            ->appendChild($this->createTextNode($journal->getSetting('publisherInstitution')));
+            ->appendChild($this->createTextNode($journal->getData('publisherInstitution')));
 
         $citationStyleLanguagePlugin = PluginRegistry::getPlugin('generic', 'citationstylelanguageplugin');
         $publisherLocation = $citationStyleLanguagePlugin?->getSetting($journal->getId(), 'publisherLocation');
-        $publisherCountry = $journal->getSetting('country');
-        $publisherUrl = $journal->getSetting('publisherUrl');
+        $publisherCountry = $journal->getData('country');
+        $publisherUrl = $journal->getData('publisherUrl');
         if ($publisherLocation || $publisherCountry || $publisherUrl) {
             $publisherLocElement = $publisherElement->appendChild($this->createElement('publisher-loc'));
             if ($publisherLocation) {
@@ -74,18 +72,17 @@ class ArticleFront extends \DOMDocument
             if ($publisherUrl) {
                 $publisherLocElement->appendChild($this->createElement('uri'))->appendChild($this->createTextNode($publisherUrl));
             }
-
         }
 
-        if (!empty($journal->getSetting('onlineIssn'))) {
+        if (!empty($journal->getData('onlineIssn'))) {
             $journalMetaElement->appendChild($this->createElement('issn'))
-                ->appendChild($this->createTextNode($journal->getSetting('onlineIssn')))->parentNode
-                ->setAttribute('pub-type','epub');
+                ->appendChild($this->createTextNode($journal->getData('onlineIssn')))->parentNode
+                ->setAttribute('pub-type', 'epub');
         }
-        if (!empty($journal->getSetting('printIssn'))) {
+        if (!empty($journal->getData('printIssn'))) {
             $journalMetaElement->appendChild($this->createElement('issn'))
-                ->appendChild($this->createTextNode($journal->getSetting('printIssn')))->parentNode
-                ->setAttribute('pub-type','ppub');
+                ->appendChild($this->createTextNode($journal->getData('printIssn')))->parentNode
+                ->setAttribute('pub-type', 'ppub');
         }
 
         $router = $request->getRouter();
@@ -97,7 +94,6 @@ class ArticleFront extends \DOMDocument
             ->setAttribute('xlink:href', $journalUrl);
 
         return $journalMetaElement;
-
     }
 
     /**
@@ -112,7 +108,9 @@ class ArticleFront extends \DOMDocument
             ->appendChild($this->createTextNode($journal->getName($journal->getPrimaryLocale())));
 
         foreach ($journal->getName(null) as $locale => $title) {
-            if ($locale == $journal->getPrimaryLocale()) continue;
+            if ($locale == $journal->getPrimaryLocale()) {
+                continue;
+            }
             $journalTitleGroupElement->appendChild($this->createElement('trans-title-group'))
                 ->setAttribute('xml:lang', str_replace(['_', '@'], '-', $locale))->parentNode
                 ->appendChild($this->createElement('trans-title'))->appendChild($this->createTextNode($title));
@@ -139,13 +137,13 @@ class ArticleFront extends \DOMDocument
         $articleMetaElement = $this->appendChild($this->createElement('article-meta'));
 
         $articleMetaElement->appendChild($this->createElement('article-id'))
-            ->setAttribute('pub-id-type','publisher-id')->parentNode
+            ->setAttribute('pub-id-type', 'publisher-id')->parentNode
             ->appendChild($this->createTextNode($submission->getId()));
 
         $articleMetaElement->appendChild($this->createElement('article-categories'))
             ->appendChild($this->createElement('subj-group'))
             ->setAttribute('xml:lang', str_replace(['_', '@'], '-', $journal->getPrimaryLocale()))->parentNode
-            ->setAttribute('subj-group-type','heading')->parentNode
+            ->setAttribute('subj-group-type', 'heading')->parentNode
             ->appendChild($this->createElement('subject'))
             ->appendChild($this->createTextNode($section->getLocalizedTitle()));
 
@@ -195,7 +193,7 @@ class ArticleFront extends \DOMDocument
 
         if ($datePublished = $publication->getData('datePublished')) {
             $datePublished = strtotime($datePublished);
-        } else if ($issue) {
+        } elseif ($issue) {
             $datePublished = $issue->getDatePublished();
         }
 
@@ -203,7 +201,7 @@ class ArticleFront extends \DOMDocument
         if ($datePublished) {
             $pubDateElement = $articleMetaElement->appendChild($this->createElement('pub-date'))
                 ->setAttribute('date-type', 'pub')->parentNode
-                ->setAttribute('publication-format','epub')->parentNode;
+                ->setAttribute('publication-format', 'epub')->parentNode;
 
             $pubDateElement->appendChild($this->createElement('day'))
                 ->appendChild($this->createTextNode(date('d', (int)$datePublished)));
@@ -223,13 +221,13 @@ class ArticleFront extends \DOMDocument
             $articleMetaElement->appendChild($this->createElement('lpage'))
                 ->appendChild($this->createTextNode($matches[1]));
             $pageCount = 1;
-        } elseif (preg_match('/^[Pp][Pp]?[.]?[ ]?(\d+)$/u', $publication->getData('pages'), $matches)) {
+        } elseif (preg_match('/^[Pp]?[Pp]?[.]?[ ]?(\d+)$/u', $publication->getData('pages'), $matches)) {
             $articleMetaElement->appendChild($this->createElement('fpage'))
                 ->appendChild($this->createTextNode($matches[1]));
             $articleMetaElement->appendChild($this->createElement('lpage'))
                 ->appendChild($this->createTextNode($matches[1]));
             $pageCount = 1;
-        } elseif (preg_match('/^[Pp][Pp]?[.]?[ ]?(\d+)[ ]?-[ ]?([Pp][Pp]?[.]?[ ]?)?(\d+)$/u', $publication->getData('pages'), $matches)) {
+        } elseif (preg_match('/^[Pp]?[Pp]?[.]?[ ]?(\d+)[ ]?-[ ]?([Pp][Pp]?[.]?[ ]?)?(\d+)$/u', $publication->getData('pages'), $matches)) {
             $matchedPageFrom = $matches[1];
             $matchedPageTo = $matches[3];
             $articleMetaElement->appendChild($this->createElement('fpage'))
@@ -250,10 +248,10 @@ class ArticleFront extends \DOMDocument
         $copyrightYear = $publication->getData('copyrightYear');
         $copyrightHolder = $publication->getLocalizedData('copyrightHolder');
         $licenseUrl = $publication->getData('licenseUrl');
-        $ccBadge = Application::get()->getCCLicenseBadge($licenseUrl, $submission->getData('locale'))=== null?'':Application::get()->getCCLicenseBadge($licenseUrl, $submission->getData('locale'));
+        $ccBadge = Application::get()->getCCLicenseBadge($licenseUrl, $submission->getData('locale')) === null ? '' : Application::get()->getCCLicenseBadge($licenseUrl, $submission->getData('locale'));
         if ($copyrightYear || $copyrightHolder || $licenseUrl || $ccBadge) {
             $permissionsElement = $articleMetaElement->appendChild($this->createElement('permissions'));
-            if ($copyrightYear || $copyrightHolder){
+            if ($copyrightYear || $copyrightHolder) {
                 $permissionsElement->appendChild($this->createElement('copyright-statement'))
                     ->appendChild($this->createTextNode(__('submission.copyrightStatement', ['copyrightYear' => $copyrightYear, 'copyrightHolder' => $copyrightHolder])));
             }
@@ -291,7 +289,9 @@ class ArticleFront extends \DOMDocument
         );
 
         foreach ($keywordVocabs as $locale => $keywords) {
-            if (empty($keywords)) continue;
+            if (empty($keywords)) {
+                continue;
+            }
 
             $kwdGroupElement = $articleMetaElement
                 ->appendChild($this->createElement('kwd-group'))
@@ -317,7 +317,11 @@ class ArticleFront extends \DOMDocument
             ->getMany();
 
         foreach ($layoutFiles as $layoutFile) {
-            $sourceFileUrl = $request->url(null, 'jatsTemplate', 'download', null,
+            $sourceFileUrl = $request->url(
+                null,
+                'jatsTemplate',
+                'download',
+                null,
                 [
                     'submissionFileId' => $layoutFile->getId(),
                     'fileId' => $layoutFile->getData('fileId'),
@@ -329,7 +333,7 @@ class ArticleFront extends \DOMDocument
                 ->appendChild($this->createElement('meta-name', 'production-ready-file-url'))->parentNode
                 ->appendChild($this->createElement('meta-value'))
                 ->appendChild($this->createElement('ext-link'))
-                ->setAttribute('ext-link-type','uri')->parentNode
+                ->setAttribute('ext-link-type', 'uri')->parentNode
                 ->setAttribute('xlink:href', $sourceFileUrl);
         }
         return $articleMetaElement;
@@ -354,7 +358,9 @@ class ArticleFront extends \DOMDocument
             }
 
             $contribElement = $contribGroupElement->appendChild($this->createElement('contrib'));
-            if ($publication->getData('primaryContactId') == $author->getId()) $contribElement->setAttribute('corresp', 'yes');
+            if ($publication->getData('primaryContactId') == $author->getId()) {
+                $contribElement->setAttribute('corresp', 'yes');
+            }
 
             // If using the CRediT plugin, credit roles may be available.
             $creditPlugin = PluginRegistry::getPlugin('generic', 'creditplugin');
@@ -364,7 +370,7 @@ class ArticleFront extends \DOMDocument
                 foreach ($contributorRoles as $role) {
                     $roleName = $creditRoles[$role];
                     $roleElement = $contribElement->appendChild($this->createElement('role'))
-                        ->setAttribute('vocab-identifier','https://credit.niso.org/')->parentNode
+                        ->setAttribute('vocab-identifier', 'https://credit.niso.org/')->parentNode
                         ->setAttribute('vocab-term', $roleName)->parentNode
                         ->setAttribute('vocab-term-identifier', $role);
 
@@ -405,12 +411,12 @@ class ArticleFront extends \DOMDocument
             if ($affiliationToken) {
                 $contribElement->appendChild($this->createElement('xref'))
                     ->setAttribute('ref-type', 'aff')->parentNode
-                    ->setAttribute( 'rid', $affiliationToken);
+                    ->setAttribute('rid', $affiliationToken);
             }
             if (($s = $author->getUrl()) != '') {
                 $contribElement->appendChild($this->createElement('uri'))
                     ->setAttribute('ref-type', 'aff')->parentNode
-                    ->setAttribute( 'rid', $affiliationToken)->parentNode
+                    ->setAttribute('rid', $affiliationToken)->parentNode
                     ->appendChild($this->createTextNode($s));
             }
 

--- a/tests/functional/ArticleBackTest.php
+++ b/tests/functional/ArticleBackTest.php
@@ -108,7 +108,7 @@ class ArticleBackTest extends PKPTestCase
             ->method('getBestGalleyId')
             ->willReturn(98);
         $galley->setId(98);
-        $galley->setData('submissionFileId',98);
+        $galley->setData('submissionFileId', 98);
         $galley->setData('doiObject', $galleyDoiObject);
 
         $galleys = [$galley];
@@ -147,7 +147,7 @@ class ArticleBackTest extends PKPTestCase
         $journal->setPrimaryLocale('en');
         $journal->setPath('journal-path');
         $journal->setData(Journal::SETTING_ENABLE_DOIS, true);
-        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know','en');
+        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know', 'en');
         $journal->setId($journalId);
 
         // Section
@@ -192,7 +192,8 @@ class ArticleBackTest extends PKPTestCase
      * test back element if citations table doesn't have records
      * @throws \DOMException
      */
-    public function testCreate(){
+    public function testCreate()
+    {
         $OAIRecord = $this->createOAIRecordMockObject();
         $record =& $OAIRecord;
         $submission =& $record->getData('article');
@@ -200,6 +201,6 @@ class ArticleBackTest extends PKPTestCase
 
         $articleBackElement = new ArticleBack();
         $xml = $articleBackElement->create($publication);
-        self::assertXmlStringEqualsXmlString('<back/>',$articleBackElement->saveXML($xml));
+        self::assertXmlStringEqualsXmlString('<back/>', $articleBackElement->saveXML($xml));
     }
 }

--- a/tests/functional/ArticleBodyTest.php
+++ b/tests/functional/ArticleBodyTest.php
@@ -107,7 +107,7 @@ class ArticleBodyTest extends PKPTestCase
             ->method('getBestGalleyId')
             ->willReturn(98);
         $galley->setId(98);
-        $galley->setData('submissionFileId',12);
+        $galley->setData('submissionFileId', 12);
         $galley->setData('doiObject', $galleyDoiObject);
 
         $galleys = [$galley];
@@ -147,7 +147,7 @@ class ArticleBodyTest extends PKPTestCase
         $journal->setPrimaryLocale('en');
         $journal->setPath('journal-path');
         $journal->setData(Journal::SETTING_ENABLE_DOIS, true);
-        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know','en');
+        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know', 'en');
         $journal->setId($journalId);
 
         // Section
@@ -193,13 +193,14 @@ class ArticleBodyTest extends PKPTestCase
      * testing body element if there is no file
      * @throws \DOMException
      */
-    public function testCreate(){
+    public function testCreate()
+    {
         $OAIRecord = $this->createOAIRecordMockObject();
         $record =& $OAIRecord;
         $submission =& $record->getData('article');
 
         $articleBodyElement = new ArticleBody();
         $xml = $articleBodyElement->create($submission);
-        self::assertXmlStringEqualsXmlString('<body/>',$articleBodyElement->saveXML($xml));
+        self::assertXmlStringEqualsXmlString('<body/>', $articleBodyElement->saveXML($xml));
     }
 }

--- a/tests/functional/ArticleFrontTest.php
+++ b/tests/functional/ArticleFrontTest.php
@@ -14,7 +14,6 @@ namespace APP\plugins\generic\jatsTemplate\functional;
 
 use PKP\doi\Doi;
 use APP\issue\Issue;
-use APP\core\Request;
 use APP\facades\Repo;
 use APP\author\Author;
 use PKP\galley\Galley;
@@ -153,7 +152,7 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
         $journal->setPrimaryLocale('en');
         $journal->setPath('journal-path');
         $journal->setData(Journal::SETTING_ENABLE_DOIS, true);
-        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know','en');
+        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know', 'en');
         $journal->setId($journalId);
 
         // Section
@@ -199,7 +198,8 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
      * testing create front element
      * @throws \DOMException
      */
-    public function testCreate(){
+    public function testCreate()
+    {
         $OAIRecord = $this->createOAIRecordMockObject();
         $record =& $OAIRecord;
         $submission =& $record->getData('article');
@@ -220,14 +220,16 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
         $xml->ownerDocument->formatOutput = true;
         self::assertEquals(
             trim(file_get_contents($this->xmlFilePath . 'frontElement.xml')),
-            trim($articleFrontElement->saveXML($xml)));
+            trim($articleFrontElement->saveXML($xml))
+        );
     }
 
     /**
      * testing create journal-meta element
      * @throws \DOMException
      */
-    public function testCreateJournalMeta(){
+    public function testCreateJournalMeta()
+    {
         $OAIRecord = $this->createOAIRecordMockObject();
         $record =& $OAIRecord;
         $journal =& $record->getData('journal');
@@ -239,15 +241,17 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
         );
         $xml->ownerDocument->formatOutput = true;
         self::assertEquals(
-            trim(file_get_contents($this->xmlFilePath.'journalMetaElement.xml')),
-            trim($articleFrontElement->saveXML($xml)));
+            trim(file_get_contents($this->xmlFilePath . 'journalMetaElement.xml')),
+            trim($articleFrontElement->saveXML($xml))
+        );
     }
 
     /**
      * testing create article-meta element
      * @throws \DOMException
      */
-    public function testCreateArticleMeta(){
+    public function testCreateArticleMeta()
+    {
         $OAIRecord = $this->createOAIRecordMockObject();
         $record =& $OAIRecord;
         $submission =& $record->getData('article');
@@ -267,15 +271,17 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
         );
         $xml->ownerDocument->formatOutput = true;
         self::assertEquals(
-            trim(file_get_contents($this->xmlFilePath.'articleMetaElement.xml')),
-            trim($articleFrontElement->saveXML($xml)));
+            trim(file_get_contents($this->xmlFilePath . 'articleMetaElement.xml')),
+            trim($articleFrontElement->saveXML($xml))
+        );
     }
 
     /**
      * testing create journal-meta journal-title-group element
      * @throws \DOMException
      */
-    public function testCreateJournalMetaJournalTitleGroup(){
+    public function testCreateJournalMetaJournalTitleGroup()
+    {
         $OAIRecord = $this->createOAIRecordMockObject();
         $record =& $OAIRecord;
         $journal =& $record->getData('journal');
@@ -285,7 +291,7 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
             $journal
         );
         self::assertXmlStringEqualsXmlFile(
-            $this->xmlFilePath.'journalMeta_JournalTitleGroupElement.xml',
+            $this->xmlFilePath . 'journalMeta_JournalTitleGroupElement.xml',
             $articleFrontElement->saveXML($xml)
         );
     }
@@ -294,7 +300,8 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
      * testing create article-meta contrib-group element
      * @throws \DOMException
      */
-    public function testCreateArticleContribGroup(){
+    public function testCreateArticleContribGroup()
+    {
         $OAIRecord = $this->createOAIRecordMockObject();
         $record =& $OAIRecord;
         $submission =& $record->getData('article');
@@ -307,9 +314,8 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
             $submission->getCurrentPublication()
         );
         self::assertXmlStringEqualsXmlFile(
-            $this->xmlFilePath.'articleMetaArticle_ContribGroupElement.xml',
+            $this->xmlFilePath . 'articleMetaArticle_ContribGroupElement.xml',
             $articleFrontElement->saveXML($xml['contribGroupElement'])
         );
     }
-
 }

--- a/tests/functional/ArticleTest.php
+++ b/tests/functional/ArticleTest.php
@@ -119,7 +119,7 @@ class ArticleTest extends PKPTestCase
             ->method('getBestGalleyId')
             ->willReturn(98);
         $galley->setId(98);
-        $galley->setData('submissionFileId',98);
+        $galley->setData('submissionFileId', 98);
         $galley->setData('doiObject', $galleyDoiObject);
 
         $galleys = [$galley];
@@ -165,7 +165,7 @@ class ArticleTest extends PKPTestCase
         $journal->setPrimaryLocale('en');
         $journal->setPath('journal-path');
         $journal->setData(Journal::SETTING_ENABLE_DOIS, true);
-        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know','en');
+        $journal->setData('abbreviation', 'publicknowledgeJ Pub Know', 'en');
         $journal->setId($journalId);
 
         // Section
@@ -212,10 +212,11 @@ class ArticleTest extends PKPTestCase
         $record = $this->createOAIRecordMockObject();
         $article = new Article();
         $article->convertOAIToXml($record, $request);
-        self::assertXmlStringEqualsXmlFile($this->xmlFilePath.'ie1.xml', $article->saveXml());
+        self::assertXmlStringEqualsXmlFile($this->xmlFilePath . 'ie1.xml', $article->saveXml());
     }
 
-    public function testMapHtmlTagsForTitle(){
+    public function testMapHtmlTagsForTitle()
+    {
         $request = $this->createRequestMockInstance();
         $expected = '<bold>test</bold>';
         $htmlString = '<b>test</b>';

--- a/tests/functional/UsesRequestMock.php
+++ b/tests/functional/UsesRequestMock.php
@@ -13,17 +13,20 @@
 namespace APP\plugins\generic\jatsTemplate\tests\functional;
 
 use APP\core\Request;
+use APP\journal\Journal;
 use PHPUnit\Framework\MockObject\MockObject;
 use PKP\core\PKPRouter;
 use PKP\core\Dispatcher;
+use PKP\core\Registry;
 
 trait UsesRequestMock
 {
     /*
      * create mock request
      */
-    protected function createRequestMockInstance(){
-        $journal = new \APP\journal\Journal();
+    protected function createRequestMockInstance()
+    {
+        $journal = new Journal();
 
         /** @var PKPRouter|MockObject */
         $dispatcher = $this->getMockBuilder(Dispatcher::class)
@@ -56,8 +59,7 @@ trait UsesRequestMock
             ->method('getContext')
             ->willReturn($journal);
 
-        \PKP\core\Registry::set('request', $requestMock);
+        Registry::set('request', $requestMock);
         return $requestMock;
     }
 }
-


### PR DESCRIPTION
- Fix page number regex as noted in pkp/pkp-lib#10786
- convert `$galleys` to array in `ArticleBody.php`
- cleanup some formatting/style

Will also backport the regex fix to 3.4/3.3 separately, and create the submodule update PR if everything looks good.