### PR TITLE
pkp/pkp-lib#12946 Add xml:lang to galley self-uri, fix citations null…

### DIFF
--- a/classes/ArticleBack.php
+++ b/classes/ArticleBack.php
@@ -34,7 +34,7 @@ class ArticleBack extends DOMDocument
         $citations = $publication->getData('citations');
         $dataCitations = $publication->getData('dataCitations');
 
-        if (!empty($citations) || !empty($dataCitations)) {
+        if (collect($citations)->isNotEmpty() || !empty($dataCitations)) {
             // create element back
             $backElement = $this->appendChild($this->createElement('back'));
 

--- a/classes/ArticleFront.php
+++ b/classes/ArticleFront.php
@@ -584,6 +584,9 @@ class ArticleFront extends DOMDocument
                 }
                 $uriNode = $articleMetaElement->appendChild($this->createElement('self-uri'));
                 $uriNode->setAttribute('xlink:href', $this->buildGalleyDownloadUrl($request, $journal, $submission, $galley));
+                if ($galley->getLocale()) {
+                    $uriNode->setAttribute('xml:lang', LocaleConversion::toBcp47($galley->getLocale()));
+                }
                 if ($galley->getLabel()) {
                     $uriNode->setAttribute('xlink:title', $galley->getLabel());
                 }

--- a/tests/data/articleMetaElement.xml
+++ b/tests/data/articleMetaElement.xml
@@ -69,7 +69,7 @@
     </license>
   </permissions>
   <self-uri xlink:href="journal-path-article-view"/>
-  <self-uri xlink:href="journal-path-article-download" xlink:title="galley-label" content-type="galley-filetype"/>
+  <self-uri xlink:href="journal-path-article-download" xml:lang="en" xlink:title="galley-label" content-type="galley-filetype"/>
   <related-article related-article-type="updated-article" specific-use="isNewVersionOf" ext-link-type="doi" xlink:href="previous-article-doi"/>
   <abstract>
     <p>article-abstract</p>

--- a/tests/data/frontElement.xml
+++ b/tests/data/frontElement.xml
@@ -125,7 +125,7 @@
       </license>
     </permissions>
     <self-uri xlink:href="journal-path-article-view"/>
-    <self-uri xlink:href="journal-path-article-download" xlink:title="galley-label" content-type="galley-filetype"/>
+    <self-uri xlink:href="journal-path-article-download" xml:lang="en" xlink:title="galley-label" content-type="galley-filetype"/>
     <related-article related-article-type="updated-article" specific-use="isNewVersionOf" ext-link-type="doi" xlink:href="previous-article-doi"/>
     <abstract>
       <p>article-abstract</p>

--- a/tests/data/ie1.xml
+++ b/tests/data/ie1.xml
@@ -132,7 +132,7 @@
                 </license>
             </permissions>
             <self-uri xlink:href="journal-path-article-view"/>
-            <self-uri xlink:href="journal-path-article-download" xlink:title="galley-label" content-type="galley-filetype"/>
+            <self-uri xlink:href="journal-path-article-download" xml:lang="en" xlink:title="galley-label" content-type="galley-filetype"/>
             <related-article related-article-type="updated-article" specific-use="isNewVersionOf" ext-link-type="doi" xlink:href="previous-article-doi"/>
             <abstract>
                 <p>article-abstract</p>

--- a/tests/functional/ArticleFrontTest.php
+++ b/tests/functional/ArticleFrontTest.php
@@ -207,6 +207,7 @@ class ArticleFrontTest extends \PKP\tests\PKPTestCase
         $galley->setData('submissionFileId', 98);
         $galley->setData('doiObject', $galleyDoiObject);
         $galley->setData('label', 'galley-label');
+        $galley->setData('locale', 'en');
 
         // Supplementary galley (genre 2 = "Research Instrument", supplementary in the test DB)
         /** @var Galley|MockObject $suppGalley */

--- a/tests/functional/ArticleTest.php
+++ b/tests/functional/ArticleTest.php
@@ -176,6 +176,7 @@ class ArticleTest extends PKPTestCase
         $galley->setData('submissionFileId', 98);
         $galley->setData('doiObject', $galleyDoiObject);
         $galley->setData('label', 'galley-label');
+        $galley->setData('locale', 'en');
 
         // Supplementary galley (genre 2 = "Research Instrument", supplementary in the test DB)
         /** @var Galley|MockObject $suppGalley */


### PR DESCRIPTION
…/array handling in back element

see https://github.com/pkp/pkp-lib/issues/12946 + a fix